### PR TITLE
feat: split along worm simulation

### DIFF
--- a/src/dmb/data/bose_hubbard_2d/worm/split.py
+++ b/src/dmb/data/bose_hubbard_2d/worm/split.py
@@ -1,0 +1,61 @@
+import random
+import re
+from collections import defaultdict
+
+import numpy as np
+
+from dmb.data.bose_hubbard_2d.worm.dataset import BoseHubbard2dDataset
+from dmb.data.split import IdDatasetSplitStrategy
+
+
+class WormSimulationsSplitStrategy(IdDatasetSplitStrategy):
+    """A strategy for splitting a Bose-Hubbard 2D worm dataset into multiple subsets."""
+
+    def split(
+        self,
+        dataset: BoseHubbard2dDataset,
+        split_fractions: dict[str, float],
+        seed: int = 42,
+    ) -> dict[str, list[str]]:
+        """Split a dataset into multiple subsets."""
+        # make sure that samples, where ids only differ by _tune, are in the same split
+
+        dataset_ids = dataset.ids
+        simulation_ids = defaultdict(list)
+        for sample_id in dataset_ids:
+            simulation_id = re.sub(r"_tune", "", sample_id)
+            simulation_ids[simulation_id].append(sample_id)
+
+        unique_simulation_ids, weights = map(
+            np.array, zip(*[(k, len(v)) for k, v in simulation_ids.items()]))
+
+        order = np.arange(len(unique_simulation_ids))
+        random.seed(seed)
+        random.shuffle(order)
+
+        agnostic_split_lengths = [
+            int(split_fraction * len(dataset))
+            for split_fraction in split_fractions.values()
+        ]
+        split_indices = [0]
+        for split_idx,split_length in enumerate(np.cumsum(agnostic_split_lengths)):
+            next_splits = np.argwhere(
+                np.cumsum(np.array(weights)[order]) > split_length)
+            if len(next_splits) == 0 or split_idx == len(agnostic_split_lengths) - 1: # enforce last split to reach the end
+                split_indices.append(len(weights))
+            else:
+                split_indices.append(int(np.min(next_splits)))
+
+ 
+
+        split_ids = {}
+        for split_name, start_index, end_index in zip(split_fractions,
+                                                      split_indices[:-1],
+                                                      split_indices[1:]):
+            split_ids[split_name] = [
+                sample_id
+                for simulation_id in unique_simulation_ids[order[start_index:end_index]]
+                for sample_id in simulation_ids[simulation_id]
+            ]
+
+        return split_ids

--- a/src/dmb/data/bose_hubbard_2d/worm/split.py
+++ b/src/dmb/data/bose_hubbard_2d/worm/split.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import numpy as np
 
 from dmb.data.bose_hubbard_2d.worm.dataset import BoseHubbard2dDataset
+from dmb.data.dataset import IdDataset
 from dmb.data.split import IdDatasetSplitStrategy
 
 
@@ -13,7 +14,7 @@ class WormSimulationsSplitStrategy(IdDatasetSplitStrategy):
 
     def split(
         self,
-        dataset: BoseHubbard2dDataset,
+        dataset: IdDataset,
         split_fractions: dict[str, float],
         seed: int = 42,
     ) -> dict[str, list[str]]:
@@ -31,22 +32,21 @@ class WormSimulationsSplitStrategy(IdDatasetSplitStrategy):
 
         order = np.arange(len(unique_simulation_ids))
         random.seed(seed)
-        random.shuffle(order)
+        random.shuffle(order)  # type: ignore
 
         agnostic_split_lengths = [
-            int(split_fraction * len(dataset))
+            int(split_fraction * len(dataset))  # type: ignore
             for split_fraction in split_fractions.values()
         ]
         split_indices = [0]
-        for split_idx,split_length in enumerate(np.cumsum(agnostic_split_lengths)):
+        for split_idx, split_length in enumerate(np.cumsum(agnostic_split_lengths)):
             next_splits = np.argwhere(
                 np.cumsum(np.array(weights)[order]) > split_length)
-            if len(next_splits) == 0 or split_idx == len(agnostic_split_lengths) - 1: # enforce last split to reach the end
+            if len(next_splits) == 0 or split_idx == len(
+                    agnostic_split_lengths) - 1:  # enforce last split to reach the end
                 split_indices.append(len(weights))
             else:
                 split_indices.append(int(np.min(next_splits)))
-
- 
 
         split_ids = {}
         for split_name, start_index, end_index in zip(split_fractions,

--- a/src/dmb/data/dataset.py
+++ b/src/dmb/data/dataset.py
@@ -21,6 +21,11 @@ class DMBData(TypedDict):
 class IdDataset(Dataset, ABC):
     """Dataset with sample IDs."""
 
+    @property
+    @abstractmethod
+    def ids(self) -> tuple[str, ...]:
+        ...
+
     @abstractmethod
     def get_ids_from_indices(self, indices: Iterable[int]) -> tuple[str, ...]:
         ...
@@ -80,6 +85,10 @@ class DMBDataset(IdDataset):
         inputs_transformed, outputs_transformed = self.transforms(inputs, outputs)
 
         return DMBData(inputs=inputs_transformed, outputs=outputs_transformed)
+
+    @property
+    def ids(self) -> tuple[str, ...]:
+        return tuple(self.sample_ids)
 
     def get_ids_from_indices(self, indices: Iterable[int]) -> tuple[str, ...]:
         return tuple(self.sample_ids[idx] for idx in indices)

--- a/src/dmb/data/split.py
+++ b/src/dmb/data/split.py
@@ -48,13 +48,14 @@ class AllIdsEqualSplitStrategy(IdDatasetSplitStrategy):
         split_indices = [0] + list(np.cumsum(split_lengths))
 
         # enforce last split to reach the end
-        split_indices[-1] = len(dataset)
+        split_indices[-1] = len(dataset)  # type: ignore
 
         split_ids = {}
         for (split_name, split_fraction), start_shuffled_idx, end_shuffled_idx in zip(
                 split_fractions.items(), split_indices[:-1], split_indices[1:]):
-            split_ids[split_name] = dataset.get_ids_from_indices(
-                dataset_indices[start_shuffled_idx:end_shuffled_idx])
+            split_ids[split_name] = list(
+                dataset.get_ids_from_indices(
+                    dataset_indices[start_shuffled_idx:end_shuffled_idx]))
 
         return split_ids
 

--- a/src/dmb/data/split.py
+++ b/src/dmb/data/split.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import random
+from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import Sized, cast
 
@@ -14,44 +15,25 @@ from torch.utils.data import Subset
 from dmb.data.dataset import IdDataset
 
 
-@define
-class Split:
-    """A Split into multiple subsets based on a dictionary of split IDs.
+class IdDatasetSplitStrategy(metaclass=ABCMeta):
+    """A strategy for splitting a dataset into multiple subsets."""
 
-    Attributes:
-        split_ids: A dictionary of split names and corresponding IDs.
-    """
+    @abstractmethod
+    def split(self,
+              dataset: IdDataset,
+              split_fractions: dict[str, float],
+              seed: int = 42) -> dict[str, list[str]]:
+        """Split a dataset into multiple subsets."""
 
-    split_ids: dict[str, tuple[str, ...]]
 
-    def apply(self, dataset: IdDataset) -> dict[str, Subset]:
-        """Apply the split to a dataset."""
-        return {
-            split_name:
-            Subset(
-                dataset=dataset,
-                indices=dataset.get_indices_from_ids(self.split_ids[split_name]),
-            )
-            for split_name in self.split_ids
-        }
+class AllIdsEqualSplitStrategy(IdDatasetSplitStrategy):
+    """A strategy for splitting a dataset into multiple subsets where all IDs are equal."""
 
-    @classmethod
-    def from_dataset(cls,
-                     dataset: IdDataset,
-                     split_fractions: dict[str, float],
-                     seed: int = 42) -> Split:
-        """Generate a split from a dataset and split fractions."""
-        split_ids = cls.generate(split_fractions, dataset, seed)
-        return cls(split_ids=split_ids)
-
-    @staticmethod
-    def generate(split_fractions: dict[str, float],
-                 dataset: IdDataset,
-                 seed: int = 42) -> dict[str, tuple[str, ...]]:
-        """Generate a split based on split fractions."""
-        if sum(split_fractions.values()) > 1.0 + 1e-8 or any(
-                fraction < 0.0 for fraction in split_fractions.values()):
-            raise ValueError("Split fractions be positive and sum to at most 1.")
+    def split(self,
+              dataset: IdDataset,
+              split_fractions: dict[str, float],
+              seed: int = 42) -> dict[str, list[str]]:
+        """Split a dataset into multiple subsets."""
 
         dataset_indices = np.arange(len(dataset))  # type: ignore
 
@@ -65,6 +47,9 @@ class Split:
 
         split_indices = [0] + list(np.cumsum(split_lengths))
 
+        # enforce last split to reach the end
+        split_indices[-1] = len(dataset)
+
         split_ids = {}
         for (split_name, split_fraction), start_shuffled_idx, end_shuffled_idx in zip(
                 split_fractions.items(), split_indices[:-1], split_indices[1:]):
@@ -72,6 +57,62 @@ class Split:
                 dataset_indices[start_shuffled_idx:end_shuffled_idx])
 
         return split_ids
+
+
+@define
+class Split:
+    """A Split into multiple subsets based on a dictionary of split IDs.
+
+    Attributes:
+        split_ids: A dictionary of split names and corresponding IDs.
+    """
+
+    split_ids: dict[str, list[str]]
+
+    def apply(self, dataset: IdDataset) -> dict[str, Subset]:
+        """Apply the split to a dataset."""
+        return {
+            split_name:
+            Subset(
+                dataset=dataset,
+                indices=dataset.get_indices_from_ids(self.split_ids[split_name]),
+            )
+            for split_name in self.split_ids
+        }
+
+    @classmethod
+    def from_dataset(
+        cls,
+        dataset: IdDataset,
+        split_fractions: dict[str, float],
+        seed: int = 42,
+        split_strategy: IdDatasetSplitStrategy | None = None,
+    ) -> Split:
+        """Generate a split from a dataset and split fractions."""
+        if not split_strategy:
+            split_strategy = AllIdsEqualSplitStrategy()
+
+        split_ids = cls.generate(
+            split_fractions=split_fractions,
+            dataset=dataset,
+            seed=seed,
+            split_strategy=split_strategy,
+        )
+        return cls(split_ids=split_ids)
+
+    @staticmethod
+    def generate(
+        split_fractions: dict[str, float],
+        dataset: IdDataset,
+        split_strategy: IdDatasetSplitStrategy,
+        seed: int = 42,
+    ) -> dict[str, list[str]]:
+        """Generate a split based on split fractions."""
+        if sum(split_fractions.values()) > 1.0 + 1e-8 or any(
+                fraction < 0.0 for fraction in split_fractions.values()):
+            raise ValueError("Split fractions be positive and sum to at most 1.")
+
+        return split_strategy.split(dataset, split_fractions, seed)
 
     @classmethod
     def from_file(cls, file_path: Path) -> Split:

--- a/src/dmb/scripts/train/configs/split/from_dataset.yaml
+++ b/src/dmb/scripts/train/configs/split/from_dataset.yaml
@@ -10,3 +10,7 @@ split_fractions:
   train: 0.96
   val: 0.02
   test: 0.02
+
+split_strategy:
+  _target_: dmb.data.bose_hubbard_2d.worm.split.WormSimulationsSplitStrategy
+  

--- a/src/job_scripts/Taskfile.yaml
+++ b/src/job_scripts/Taskfile.yaml
@@ -101,8 +101,8 @@ tasks:
           QMC_SCRIPT_FILE: create_random.py
           QMC_TASK_ARGS: "--type random --number_of_samples 250" #--U_on_max 0.4 --V_nn_z_min 0.85 --V_nn_z_max 1.15 --mu_offset_min 1.5
           NUMBER_OF_CONCURRENT_JOBS: 50
-          NUMBER_OF_SAMPLES: 250
-          SLURM_ARRAY_SIZE: 10
+          NUMBER_OF_SAMPLES: 2500
+          SLURM_ARRAY_SIZE: 1
 
   run_qmc_box:
     desc: Run QMC on the box potential

--- a/src/tests/data/test_split.py
+++ b/src/tests/data/test_split.py
@@ -3,10 +3,16 @@ from typing import Any, Iterable
 
 import pytest
 from attrs import define, field
+from pytest_cases import case, parametrize_with_cases
 
+from dmb.data.bose_hubbard_2d.worm.split import WormSimulationsSplitStrategy
 from dmb.data.dataset import IdDataset
-from dmb.data.split import Split
-
+from dmb.data.split import AllIdsEqualSplitStrategy, IdDatasetSplitStrategy, \
+    Split
+from pytest_cases import filters
+import numpy as np 
+import re 
+import itertools
 
 def validate_same_length(instance: Any, attribute: Any, value: Any) -> None:
     """Validate that the ids and indices have the same length."""
@@ -49,12 +55,27 @@ class FakeIdDataset(IdDataset):
         return self.indices[idx], self.ids[idx]
 
 
-class TestSplit:
-    """Test the Split class."""
+class SplitStrategyCases:
+    """Test cases for the IdDatasetSplitStrategy."""
 
     @staticmethod
-    @pytest.fixture(scope="class", name="id_dataset")
-    def get_id_dataset() -> FakeIdDataset:
+    @case(tags=("split_strategy", "general"))
+    def case_all_ids_equal_split_strategy() -> IdDatasetSplitStrategy:
+        """Return an instance of the AllIdsEqualSplitStrategy."""
+        return AllIdsEqualSplitStrategy()
+
+    @staticmethod
+    @case(tags=("split_strategy", "worm"))
+    def case_worm_simulations_split_strategy() -> IdDatasetSplitStrategy:
+        """Return an instance of the WormSimulationsSplitStrategy."""
+        return WormSimulationsSplitStrategy()
+
+
+class SplitDataCases:
+
+    @staticmethod
+    @case(tags=("id_dataset","general"))
+    def case_id_dataset() -> FakeIdDataset:
         """Return a fake id dataset."""
         return FakeIdDataset(
             ids=("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"),
@@ -62,184 +83,259 @@ class TestSplit:
         )
 
     @staticmethod
-    @pytest.fixture(scope="class", name="test_split_ids")
-    def get_test_split_ids() -> tuple[dict[str, list[str]], ...]:
-        """Return test split ids."""
+    @case(tags=("split_data", "general"))
+    @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
+    def case_split_data_1(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
+        dict[str, list[str]], dict[str, list[str]], dict[
+        str, float], dict[str, int]]:
+        """Return a split data dictionary."""
         return (
+            id_dataset,
             {
-                "train": ["a", "b", "i", "c"],
-                "test": ["d", "e"]
-            },
-            {
-                "train": ["a", "b", "c", "m", "e"],
-                "test": ["f", "g", "h", "i", "j"]
-            },
-            {
-                "train": ["a", "b", "d", "e", "f", "g"],
-                "val": ["h", "z"],
-                "test": ["i", "j"],
-            },
-            {
-                "train": ["i", "j"],
-                "val": ["h"],
-                "test": ["a", "b", "c", "d", "e", "f", "g"],
-            },
-            {
-                "test": ["g"]
-            },
-            {
-                "test": [
-                    "x",
-                ]
-            },
-        )
+            "train": ["a", "b", "i", "c"],
+            "test": ["d", "e"]
+        }, {
+            "train": [0, 1, 2, 8],
+            "test": [3, 4],
+        }, {
+            "train": 0.4,
+            "test": 0.6
+        }, {
+            "train": 4,
+            "test": 6
+        })
 
     @staticmethod
-    @pytest.fixture(scope="class", name="test_subset_indices")
-    def get_test_subset_indices() -> tuple[dict[str, tuple[int, ...]], ...]:
-        """Return test subset indices."""
+    @case(tags=("split_data", "general"))
+    @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
+    def case_split_data_2(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
+        dict[str, list[str]], dict[str, list[str]], dict[
+        str, float], dict[str, int]]:
+        """Return a split data dictionary."""
         return (
+            id_dataset,
             {
-                "train": (0, 1, 2, 8),
-                "test": (3, 4),
-            },
-            {
-                "train": (0, 1, 2, 4),
-                "test": (5, 6, 7, 8, 9),
-            },
-            {
-                "train": (0, 1, 3, 4, 5, 6),
-                "val": (7, ),
-                "test": (8, 9),
-            },
-            {
-                "train": (8, 9),
-                "val": (7, ),
-                "test": (0, 1, 2, 3, 4, 5, 6),
-            },
-            {
-                "test": (6, ),
-            },
-            {
-                "test": (),
-            },
-        )
+            "train": ["a", "b", "c", "d", "e", "f", "g"],
+            "val": ["h", "z"],
+            "test": ["i", "j"],
+        }, {
+            "train": [0, 1, 2, 3, 4, 5, 6],
+            "val": [7],
+            "test": [8, 9],
+        }, {
+            "train": 0.6,
+            "val": 0.1,
+            "test": 0.3
+        }, {
+            "train": 6,
+            "val": 1,
+            "test": 3
+        })
 
     @staticmethod
-    @pytest.fixture(scope="class", name="test_split_fractions")
-    def get_test_split_fractions() -> tuple[dict[str, float], ...]:
-        """Return test split fractions."""
+    @case(tags=("split_data", "general"))
+    @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
+    def case_split_data_3(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
+        dict[str, list[str]], dict[str, list[str]], dict[
+        str, float], dict[str, int]]:   
+        """Return a split data dictionary."""
+
         return (
+            id_dataset,
             {
-                "train": 0.4,
-                "test": 0.6
-            },
-            {
-                "train": 0.5,
-                "test": 0.5
-            },
-            {
-                "train": 0.6,
-                "val": 0.1,
-                "test": 0.3
-            },
-            {
-                "train": 0.2,
-                "val": 0.1,
-                "test": 0.7
-            },
-            {
-                "test": 1.0
-            },
-            {
-                "test": 0.0,
-                "train": 0.8
-            },
-        )
+            "train": ["i", "j"],
+            "val": ["h"],
+            "test": ["a", "b", "c", "d", "e", "f", "g"],
+        }, {
+            "train": [8, 9],
+            "val": [7],
+            "test": [0, 1, 2, 3, 4, 5, 6],
+        }, {
+            "train": 0.2,
+            "val": 0.1,
+            "test": 0.7
+        }, {
+            "train": 2,
+            "val": 1,
+            "test": 7
+        })
 
     @staticmethod
-    @pytest.fixture(scope="class", name="test_subset_lengths")
-    def get_test_subset_lengths() -> tuple[dict[str, int], ...]:
-        """Return test subset lengths."""
+    @case(tags=("split_data", "general"))
+    @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
+    def case_split_data_4(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
+        dict[str, list[str]], dict[str, list[str]], dict[
+        str, float], dict[str, int]]:
+        """Return a split data dictionary."""
         return (
+            id_dataset,
             {
-                "train": 4,
-                "test": 6
-            },
-            {
-                "train": 5,
-                "test": 5
-            },
-            {
-                "train": 6,
-                "val": 1,
-                "test": 3
-            },
-            {
-                "train": 2,
-                "val": 1,
-                "test": 7
-            },
-            {
-                "test": 10
-            },
-            {
-                "test": 0,
-                "train": 8
-            },
-        )
+            "test": ["g"]
+        }, {
+            "test": [6],
+        }, {
+            "test": 1.0
+        }, {
+            "test": 10
+        })
 
     @staticmethod
+    @case(tags=("split_data", "general"))
+    @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
+    def case_split_data_5(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
+        dict[str, list[str]], dict[str, list[str]], dict[
+        str, float], dict[str, int]]:
+        """Return a split data dictionary."""
+        return (
+            id_dataset,
+            {
+            "test": ["x"]
+        }, {
+            "test": [],
+        }, {
+            "test": 0.0,
+        }, {
+            "test": 10
+        })
+
+
+    @staticmethod
+    @case(tags=("id_dataset", "worm"))
+    def case_id_dataset_worm() -> FakeIdDataset:
+        """Return a fake id dataset."""
+        return FakeIdDataset(
+            ids=("a","a_tune", "b_tune", "c_tune", "d", "e","e_tune", "f", "g", "g_tune"),
+            indices=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+        )
+
+
+class TestSplit:
+    """Test the Split class."""
+
+    @staticmethod
+    @parametrize_with_cases("id_dataset, split_ids, subset_indices",
+                            cases=SplitDataCases,
+                            filter=filters.has_tag("split_data")
+                            )
     def test_apply(
         id_dataset: FakeIdDataset,
-        test_split_ids: tuple[dict[str, tuple[str, ...]]],
-        test_subset_indices: tuple[dict[str, tuple[int, ...]], ...],
+        split_ids: dict[str, list[str]],
+        subset_indices: dict[str, list[int]],
     ) -> None:
         """Test the apply method."""
-        for split_ids, subset_indices in zip(test_split_ids, test_subset_indices):
-            split = Split(split_ids=split_ids)
-            subsets = split.apply(id_dataset)
+        # for split_ids, subset_indices in zip(test_split_ids, test_subset_indices):
+        split = Split(split_ids=split_ids)
+        subsets = split.apply(id_dataset)
 
-            for split_name, subset in subsets.items():
-                assert len(subset) == len(subset_indices[split_name])
-                assert all(subset[idx] == id_dataset[subset_idx]
-                           for idx, subset_idx in enumerate(subset_indices[split_name]))
+        for split_name, subset in subsets.items():
+            assert len(subset) == len(subset_indices[split_name])
+            assert all(subset[idx] == id_dataset[subset_idx]
+                       for idx, subset_idx in enumerate(subset_indices[split_name]))
 
     @staticmethod
+    @parametrize_with_cases(
+        "split_strategy",
+        cases=SplitStrategyCases,
+    )
+    @parametrize_with_cases("id_dataset, split_ids, subset_indices, split_fractions, subset_lengths",
+                            cases=SplitDataCases,
+                            filter=filters.has_tag("split_data")
+                            )
     def test_generate(
         id_dataset: FakeIdDataset,
-        test_split_fractions: tuple[dict[str, float]],
-        test_subset_lengths: tuple[dict[str, int]],
+        split_ids: dict[str, list[str]],
+        subset_indices: dict[str, list[int]],
+        split_fractions: dict[str, float],
+        subset_lengths: dict[str, int],
+        split_strategy: IdDatasetSplitStrategy,
     ) -> None:
         """Test the generate method."""
-        for split_fractions, subset_lengths in zip(test_split_fractions,
-                                                   test_subset_lengths):
-            split_ids = Split.generate(split_fractions, id_dataset)
+        split_ids = Split.generate(
+            split_fractions=split_fractions,
+            dataset=id_dataset,
+            split_strategy=split_strategy,
+        )
 
-            assert set(split_ids.keys()) == set(split_fractions.keys())
-            assert all(
-                len(split_ids[split_name]) == subset_lengths[split_name]
-                for split_name in split_fractions)
+        assert set(split_ids.keys()) == set(split_fractions.keys())
+        assert all(
+            len(split_ids[split_name]) == subset_lengths[split_name]
+            for split_name in split_fractions)
 
     @staticmethod
+    @parametrize_with_cases(
+        "id_dataset, split_ids, subset_indices, split_fractions, subset_lengths",
+        cases=SplitDataCases,
+        filter=filters.has_tag("split_data"),
+    )
     def test_to_from_file(
-        test_split_ids: tuple[dict[str, tuple[str, ...]]],
+        id_dataset: FakeIdDataset,
+        split_ids: tuple[dict[str, tuple[str, ...]]],
+        subset_indices: tuple[dict[str, tuple[int, ...]], ...],
+        split_fractions: tuple[dict[str, float]],
+        subset_lengths: tuple[dict[str, int]],
         tmp_path: Path,
     ) -> None:
         """Test the to_file and from_file methods."""
-        for split_ids in test_split_ids:
-            split = Split(split_ids=split_ids)
-            split.to_file(tmp_path / "split.json")
+        split = Split(split_ids=split_ids)
+        split.to_file(tmp_path / "split.json")
 
-            loaded_split = Split.from_file(tmp_path / "split.json")
+        loaded_split = Split.from_file(tmp_path / "split.json")
 
-            assert split.split_ids == loaded_split.split_ids
+        assert split.split_ids == loaded_split.split_ids
 
     @staticmethod
-    def test_split_fractions_check(id_dataset: FakeIdDataset) -> None:
+    @parametrize_with_cases("split_strategy", cases=SplitStrategyCases)
+    @parametrize_with_cases("id_dataset", cases=SplitDataCases,
+                            filter=filters.has_tag("id_dataset"))
+    def test_split_fractions_check(id_dataset: FakeIdDataset,
+                                   split_strategy: IdDatasetSplitStrategy) -> None:
         """Test the split fractions check."""
         with pytest.raises(ValueError):
-            Split.generate({"train": 0.5, "test": 0.6}, id_dataset)
+            Split.generate(
+                split_fractions={
+                    "train": 0.5,
+                    "test": 0.6
+                },
+                dataset=id_dataset,
+                split_strategy=split_strategy,
+            )
 
         with pytest.raises(ValueError):
-            Split.generate({"train": -0.5, "test": 0.5}, id_dataset)
+            Split.generate(
+                split_fractions={
+                    "train": -0.5,
+                    "test": 0.5
+                },
+                dataset=id_dataset,
+                split_strategy=split_strategy,
+            )
+
+    @staticmethod
+    @parametrize_with_cases("split_strategy", cases=SplitStrategyCases,
+                            filter=filters.has_tag("worm"))
+    @parametrize_with_cases("id_dataset", cases=SplitDataCases,
+                            filter=filters.has_tag("id_dataset") & filters.has_tag("worm"))
+    def test_split_worm_id_dataset(id_dataset: FakeIdDataset,
+                                   split_strategy: IdDatasetSplitStrategy) -> None:
+        """Test worm dataset split."""
+
+        for _ in range(100):
+            split_abs_sizes = {
+                f"split_fraction_{idx}": int(np.random.randint(1, 100)) for idx in range(np.random.randint(1, 5))
+            }
+            split_fractions = {
+                key: value / sum(split_abs_sizes.values()) for key, value in split_abs_sizes.items()
+            }
+
+            split_ids = Split.generate(
+                split_fractions=split_fractions,
+                dataset=id_dataset,
+                split_strategy=split_strategy,
+            )
+
+            assert sum(len(ids) for ids in split_ids.values()) == len(id_dataset)
+            simulation_ids = {key: set(re.sub("_tune","",sample_id) for sample_id in value) for key, value in split_ids.items()}
+
+            # check pairwise intersection are empty
+            for key1, key2 in itertools.combinations(simulation_ids.keys(), 2):
+                assert len(simulation_ids[key1].intersection(simulation_ids[key2])) == 0

--- a/src/tests/data/test_split.py
+++ b/src/tests/data/test_split.py
@@ -1,18 +1,18 @@
+import itertools
+import re
 from pathlib import Path
 from typing import Any, Iterable
 
+import numpy as np
 import pytest
 from attrs import define, field
-from pytest_cases import case, parametrize_with_cases
+from pytest_cases import case, filters, parametrize_with_cases
 
 from dmb.data.bose_hubbard_2d.worm.split import WormSimulationsSplitStrategy
 from dmb.data.dataset import IdDataset
 from dmb.data.split import AllIdsEqualSplitStrategy, IdDatasetSplitStrategy, \
     Split
-from pytest_cases import filters
-import numpy as np 
-import re 
-import itertools
+
 
 def validate_same_length(instance: Any, attribute: Any, value: Any) -> None:
     """Validate that the ids and indices have the same length."""
@@ -74,7 +74,7 @@ class SplitStrategyCases:
 class SplitDataCases:
 
     @staticmethod
-    @case(tags=("id_dataset","general"))
+    @case(tags=("id_dataset", "general"))
     def case_id_dataset() -> FakeIdDataset:
         """Return a fake id dataset."""
         return FakeIdDataset(
@@ -85,13 +85,12 @@ class SplitDataCases:
     @staticmethod
     @case(tags=("split_data", "general"))
     @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
-    def case_split_data_1(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
-        dict[str, list[str]], dict[str, list[str]], dict[
-        str, float], dict[str, int]]:
+    def case_split_data_1(
+        id_dataset: FakeIdDataset
+    ) -> tuple[FakeIdDataset, dict[str, list[str]], dict[str, list[int]], dict[
+            str, float], dict[str, int]]:
         """Return a split data dictionary."""
-        return (
-            id_dataset,
-            {
+        return (id_dataset, {
             "train": ["a", "b", "i", "c"],
             "test": ["d", "e"]
         }, {
@@ -108,13 +107,12 @@ class SplitDataCases:
     @staticmethod
     @case(tags=("split_data", "general"))
     @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
-    def case_split_data_2(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
-        dict[str, list[str]], dict[str, list[str]], dict[
-        str, float], dict[str, int]]:
+    def case_split_data_2(
+        id_dataset: FakeIdDataset
+    ) -> tuple[FakeIdDataset, dict[str, list[str]], dict[str, list[int]], dict[
+            str, float], dict[str, int]]:
         """Return a split data dictionary."""
-        return (
-            id_dataset,
-            {
+        return (id_dataset, {
             "train": ["a", "b", "c", "d", "e", "f", "g"],
             "val": ["h", "z"],
             "test": ["i", "j"],
@@ -135,14 +133,13 @@ class SplitDataCases:
     @staticmethod
     @case(tags=("split_data", "general"))
     @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
-    def case_split_data_3(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
-        dict[str, list[str]], dict[str, list[str]], dict[
-        str, float], dict[str, int]]:   
+    def case_split_data_3(
+        id_dataset: FakeIdDataset
+    ) -> tuple[FakeIdDataset, dict[str, list[str]], dict[str, list[int]], dict[
+            str, float], dict[str, int]]:
         """Return a split data dictionary."""
 
-        return (
-            id_dataset,
-            {
+        return (id_dataset, {
             "train": ["i", "j"],
             "val": ["h"],
             "test": ["a", "b", "c", "d", "e", "f", "g"],
@@ -163,13 +160,12 @@ class SplitDataCases:
     @staticmethod
     @case(tags=("split_data", "general"))
     @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
-    def case_split_data_4(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
-        dict[str, list[str]], dict[str, list[str]], dict[
-        str, float], dict[str, int]]:
+    def case_split_data_4(
+        id_dataset: FakeIdDataset
+    ) -> tuple[FakeIdDataset, dict[str, list[str]], dict[str, list[int]], dict[
+            str, float], dict[str, int]]:
         """Return a split data dictionary."""
-        return (
-            id_dataset,
-            {
+        return (id_dataset, {
             "test": ["g"]
         }, {
             "test": [6],
@@ -182,13 +178,12 @@ class SplitDataCases:
     @staticmethod
     @case(tags=("split_data", "general"))
     @parametrize_with_cases("id_dataset", cases=case_id_dataset, has_tag="general")
-    def case_split_data_5(id_dataset: FakeIdDataset) -> tuple[FakeIdDataset,
-        dict[str, list[str]], dict[str, list[str]], dict[
-        str, float], dict[str, int]]:
+    def case_split_data_5(
+        id_dataset: FakeIdDataset
+    ) -> tuple[FakeIdDataset, dict[str, list[str]], dict[str, list[int]], dict[
+            str, float], dict[str, int]]:
         """Return a split data dictionary."""
-        return (
-            id_dataset,
-            {
+        return (id_dataset, {
             "test": ["x"]
         }, {
             "test": [],
@@ -198,13 +193,13 @@ class SplitDataCases:
             "test": 10
         })
 
-
     @staticmethod
     @case(tags=("id_dataset", "worm"))
     def case_id_dataset_worm() -> FakeIdDataset:
         """Return a fake id dataset."""
         return FakeIdDataset(
-            ids=("a","a_tune", "b_tune", "c_tune", "d", "e","e_tune", "f", "g", "g_tune"),
+            ids=("a", "a_tune", "b_tune", "c_tune", "d", "e", "e_tune", "f", "g",
+                 "g_tune"),
             indices=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
         )
 
@@ -215,8 +210,7 @@ class TestSplit:
     @staticmethod
     @parametrize_with_cases("id_dataset, split_ids, subset_indices",
                             cases=SplitDataCases,
-                            filter=filters.has_tag("split_data")
-                            )
+                            filter=filters.has_tag("split_data"))
     def test_apply(
         id_dataset: FakeIdDataset,
         split_ids: dict[str, list[str]],
@@ -237,10 +231,10 @@ class TestSplit:
         "split_strategy",
         cases=SplitStrategyCases,
     )
-    @parametrize_with_cases("id_dataset, split_ids, subset_indices, split_fractions, subset_lengths",
-                            cases=SplitDataCases,
-                            filter=filters.has_tag("split_data")
-                            )
+    @parametrize_with_cases(
+        "id_dataset, split_ids, subset_indices, split_fractions, subset_lengths",
+        cases=SplitDataCases,
+        filter=filters.has_tag("split_data"))
     def test_generate(
         id_dataset: FakeIdDataset,
         split_ids: dict[str, list[str]],
@@ -269,10 +263,10 @@ class TestSplit:
     )
     def test_to_from_file(
         id_dataset: FakeIdDataset,
-        split_ids: tuple[dict[str, tuple[str, ...]]],
-        subset_indices: tuple[dict[str, tuple[int, ...]], ...],
-        split_fractions: tuple[dict[str, float]],
-        subset_lengths: tuple[dict[str, int]],
+        split_ids: dict[str, list[str]],
+        subset_indices: dict[str, list[int]],
+        split_fractions: dict[str, float],
+        subset_lengths: dict[str, int],
         tmp_path: Path,
     ) -> None:
         """Test the to_file and from_file methods."""
@@ -285,7 +279,8 @@ class TestSplit:
 
     @staticmethod
     @parametrize_with_cases("split_strategy", cases=SplitStrategyCases)
-    @parametrize_with_cases("id_dataset", cases=SplitDataCases,
+    @parametrize_with_cases("id_dataset",
+                            cases=SplitDataCases,
                             filter=filters.has_tag("id_dataset"))
     def test_split_fractions_check(id_dataset: FakeIdDataset,
                                    split_strategy: IdDatasetSplitStrategy) -> None:
@@ -311,20 +306,25 @@ class TestSplit:
             )
 
     @staticmethod
-    @parametrize_with_cases("split_strategy", cases=SplitStrategyCases,
+    @parametrize_with_cases("split_strategy",
+                            cases=SplitStrategyCases,
                             filter=filters.has_tag("worm"))
-    @parametrize_with_cases("id_dataset", cases=SplitDataCases,
-                            filter=filters.has_tag("id_dataset") & filters.has_tag("worm"))
+    @parametrize_with_cases("id_dataset",
+                            cases=SplitDataCases,
+                            filter=filters.has_tag("id_dataset")
+                            & filters.has_tag("worm"))
     def test_split_worm_id_dataset(id_dataset: FakeIdDataset,
                                    split_strategy: IdDatasetSplitStrategy) -> None:
         """Test worm dataset split."""
 
         for _ in range(100):
             split_abs_sizes = {
-                f"split_fraction_{idx}": int(np.random.randint(1, 100)) for idx in range(np.random.randint(1, 5))
+                f"split_fraction_{idx}": int(np.random.randint(1, 100))
+                for idx in range(np.random.randint(1, 5))
             }
             split_fractions = {
-                key: value / sum(split_abs_sizes.values()) for key, value in split_abs_sizes.items()
+                key: value / sum(split_abs_sizes.values())
+                for key, value in split_abs_sizes.items()
             }
 
             split_ids = Split.generate(
@@ -334,8 +334,11 @@ class TestSplit:
             )
 
             assert sum(len(ids) for ids in split_ids.values()) == len(id_dataset)
-            simulation_ids = {key: set(re.sub("_tune","",sample_id) for sample_id in value) for key, value in split_ids.items()}
+            simulation_ids = {
+                key: set(re.sub("_tune", "", sample_id) for sample_id in value)
+                for key, value in split_ids.items()
+            }
 
             # check pairwise intersection are empty
-            for key1, key2 in itertools.combinations(simulation_ids.keys(), 2):
+            for key1, key2 in itertools.combinations(simulation_ids, 2):
                 assert len(simulation_ids[key1].intersection(simulation_ids[key2])) == 0


### PR DESCRIPTION
Splits for worm simulations should respect simulation ids, if tune simulations are included in the dataset.

Changes:
- Splitting is changed to strategy pattern
- A default strategy is implemented which disregards sample id patterns
- A worm simulations splitting strategy is added, which places simulations and respective tune simulations into the same split